### PR TITLE
Find syscall by number (and some code re-structure)

### DIFF
--- a/syscall.py
+++ b/syscall.py
@@ -5,12 +5,9 @@ import sys
 from os import path
 import subprocess
 import re
+import argparse
 
-if len(sys.argv) < 3:
-    print('Usage: syscall <arch> <syscall>')
-    exit()
-
-infos = {
+ARCHITECTURES = {
     'arm64':('aarch64-linux',('x0','x1','x2','x3','x4','x5'),('svc #0','x8','x0')),
     'x64':('amd64-linux',('rdi','rsi','rdx','r10','r8','r9'),('syscall','rax','rax')),
     'arm':('arm-linux',('r0','r1','r2','r3','r4','r5'),('swi 0x0','r7','r0')),
@@ -24,12 +21,17 @@ infos = {
     'sparc64':('sparc-n-linux',('o0','o1','o2','o3','o4','o5'),('t','0x6d','g1','o0'))
 }
 
-arch = sys.argv[1]
-name = sys.argv[2]
+parser = argparse.ArgumentParser(description='Lookup syscall information.')
+parser.add_argument('arch', help='The target architecture', choices=ARCHITECTURES.keys())
+parser.add_argument('syscall', help='The syscall name/number to look up')
+args = parser.parse_args()
 
-filename = infos[arch][0]
-order = infos[arch][1]
-instruction_sys_ret = infos[arch][2]
+arch = args.arch
+name = args.syscall
+
+filename = ARCHITECTURES[arch][0]
+order = ARCHITECTURES[arch][1]
+instruction_sys_ret = ARCHITECTURES[arch][2]
 filepath = path.join(path.dirname(path.realpath(__file__)), 'syscalls', f'{filename}.xml')
 
 syscall = ET.parse(f'{filepath}').getroot().find(f"./syscall[@name='{name}']").attrib['number']

--- a/syscall.py
+++ b/syscall.py
@@ -2,7 +2,7 @@
 
 import xml.etree.ElementTree as ET
 import sys
-import os
+from os import path
 import subprocess
 import re
 
@@ -24,22 +24,22 @@ infos = {
     'sparc64':('sparc-n-linux',('o0','o1','o2','o3','o4','o5'),('t','0x6d','g1','o0'))
 }
 
-
 arch = sys.argv[1]
+name = sys.argv[2]
+
 filename = infos[arch][0]
 order = infos[arch][1]
 instruction_sys_ret = infos[arch][2]
-name = sys.argv[2]
-filepath = os.path.dirname(os.path.realpath(__file__))+'/syscalls/'+filename+'.xml'
+filepath = path.join(path.dirname(path.realpath(__file__)), 'syscalls', f'{filename}.xml')
 
-syscall = ET.parse('{}'.format(filepath)).getroot().find("./syscall[@name='{}']".format(name)).attrib['number']
-man = subprocess.check_output('man {}'.format(name), shell=True).decode()
-declaration = re.search('{}\(.*\n?.*\);'.format(name),man)
+syscall = ET.parse(f'{filepath}').getroot().find(f"./syscall[@name='{name}']").attrib['number']
+man = subprocess.check_output(f'man {name}', shell=True).decode()
+declaration = re.search(f'{name}\\(.*\n?.*\\);', man)
 if not declaration:
-    man = subprocess.check_output('man {}.2'.format(name), shell=True).decode()
-    declaration = re.search('{}\(.*\n?.*\);'.format(name),man)
+    man = subprocess.check_output(f'man {name}.2', shell=True).decode()
+    declaration = re.search(f'{name}\\(.*\n?.*\\);', man)
 
-print('For {}:'.format(arch))
+print(f'For {arch}:')
 print('The instruction is {}, the syscall register is {}, and the return register is {}'.format(*instruction_sys_ret))
 print('The registers for the arguments are: {}'.format(', '.join(order)))
 print('The syscall is {}/{}'.format(hex(int(syscall)),syscall))

--- a/syscall.py
+++ b/syscall.py
@@ -16,9 +16,8 @@ ARCHITECTURES = {
     'mips64':('mips-n64-linux',('a0','a1','a2','a3','a4','a5'),('syscall','v0','v0')),
     'ppc64':('ppc-n64-linux',('r3','r4','r5','r6','r7','r8'),('sc','r0','r3')),
     'ppc':('ppc-n-linux',('r3','r4','r5','r6','r7','r8'),('sc','r0','r3')),
-    'sparc64':'sparch-n64-linux',
-    'sparc':('sparc-n-linux',('o0','o1','o2','o3','o4','o5'),('t','0x10','g1','o0')),
-    'sparc64':('sparc-n-linux',('o0','o1','o2','o3','o4','o5'),('t','0x6d','g1','o0'))
+    'sparc':('sparc-linux',('o0','o1','o2','o3','o4','o5'),('t','0x10','g1','o0')),
+    'sparc64':('sparc64-linux',('o0','o1','o2','o3','o4','o5'),('t','0x6d','g1','o0'))
 }
 
 parser = argparse.ArgumentParser(description='Lookup syscall information.')
@@ -29,9 +28,7 @@ args = parser.parse_args()
 arch = args.arch
 name = args.syscall
 
-filename = ARCHITECTURES[arch][0]
-order = ARCHITECTURES[arch][1]
-instruction_sys_ret = ARCHITECTURES[arch][2]
+filename, order, instruction_sys_ret = ARCHITECTURES[arch]
 filepath = path.join(path.dirname(path.realpath(__file__)), 'syscalls', f'{filename}.xml')
 
 syscall = ET.parse(f'{filepath}').getroot().find(f"./syscall[@name='{name}']").attrib['number']


### PR DESCRIPTION
This PR adds the ability to lookup the syscall by number, for example:

`python3 syscall.py x86 execve`

> For x86:
> The instruction is int $0x80, the syscall register is eax, and the return register is eax
> The registers for the arguments are: ebx, ecx, edx, esi, edi, ebp
> The syscall is 0xb/11
> The syscall function declaration is: 
> execve(const char *filename, char *const argv[],
>                   char *const envp[]);

produces the same output as

`python3 syscall.py x86 11`

> For x86:
> The instruction is int $0x80, the syscall register is eax, and the return register is eax
> The registers for the arguments are: ebx, ecx, edx, esi, edi, ebp
> The syscall is 0xb/11
> The syscall function declaration is: 
> execve(const char *filename, char *const argv[],
>                   char *const envp[]);

I also fixed an error (the sparc entries were incorrect) and added argparse instead of manually fetching arguments (gives a nice help prompt and validates the architechure option as well). You can of course scrap those changes if you prefer.
